### PR TITLE
Convert luthersystems/shiroclient-sdk-go to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: luthersystems/build-go:0.0.51
-    steps:
-      - checkout
-      - run: echo $LUTHER_LICENSE | base64 -d > .luther-license.yaml
-      - run: make citest

--- a/.github/workflows/shiroclient-sdk-go.yml
+++ b/.github/workflows/shiroclient-sdk-go.yml
@@ -1,0 +1,16 @@
+name: luthersystems/shiroclient-sdk-go/luthersystems/shiroclient-sdk-go
+on:
+  push:
+    branches:
+    - main
+env:
+  LUTHER_LICENSE: xxxxTT0K
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: luthersystems/build-go:0.0.51
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - run: echo $LUTHER_LICENSE | base64 -d > .luther-license.yaml
+    - run: make citest

--- a/.github/workflows/shiroclient-sdk-go.yml
+++ b/.github/workflows/shiroclient-sdk-go.yml
@@ -1,10 +1,8 @@
-name: luthersystems/shiroclient-sdk-go/luthersystems/shiroclient-sdk-go
+name: CI Tests
 on:
-  push:
+  pull_request:
     branches:
     - main
-env:
-  LUTHER_LICENSE: xxxxTT0K
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,5 +10,9 @@ jobs:
       image: luthersystems/build-go:0.0.51
     steps:
     - uses: actions/checkout@v3.5.0
-    - run: echo $LUTHER_LICENSE | base64 -d > .luther-license.yaml
-    - run: make citest
+    - name: Set license file
+      run: echo $LUTHER_LICENSE | base64 -d > .luther-license.yaml
+      env:
+        LUTHER_LICENSE: ${{ secrets.LUTHER_LICENSE }}
+    - name: Run CI tests
+      run: make citest


### PR DESCRIPTION
Pipeline migrated from [CircleCI](https://app.circleci.com/pipelines/github/luthersystems/shiroclient-sdk-go) :tada:

## Manual steps

Perform the following steps to complete the migration:

### luthersystems/shiroclient-sdk-go/luthersystems/shiroclient-sdk-go
- [ ] Ensure environment variable is updated: `LUTHER_LICENSE`