### PR TITLE
thread contexts

### DIFF
--- a/internal/mock/shiroclient.go
+++ b/internal/mock/shiroclient.go
@@ -34,9 +34,8 @@ type mockShiroClient struct {
 	shiroPhylum string
 }
 
-func (c *mockShiroClient) flatten(configs ...types.Config) (*plugin.ConcreteRequestOptions, error) {
-	ctx := context.TODO()
-	opt := types.ApplyConfigs(ctx, nil, append(c.baseConfig, configs...)...)
+func (c *mockShiroClient) flatten(ctx context.Context, configs ...types.Config) (*plugin.ConcreteRequestOptions, error) {
+	opt := types.ApplyConfigs(nil, append(c.baseConfig, configs...)...)
 
 	params, err := json.Marshal(opt.Params)
 	if err != nil {
@@ -68,7 +67,7 @@ func (c *mockShiroClient) flatten(configs ...types.Config) (*plugin.ConcreteRequ
 		AuthToken:           opt.AuthToken,
 		Params:              params,
 		Transient:           opt.Transient,
-		Timestamp:           tsg(opt.Ctx, opt.TimestampGenerator),
+		Timestamp:           tsg(ctx, opt.TimestampGenerator),
 		MSPFilter:           opt.MspFilter,
 		MinEndorsers:        opt.MinEndorsers,
 		Creator:             opt.Creator,
@@ -83,18 +82,18 @@ func (c *mockShiroClient) flatten(configs ...types.Config) (*plugin.ConcreteRequ
 }
 
 // Seed implements the ShiroClient interface.
-func (c *mockShiroClient) Seed(version string, configs ...types.Config) error {
+func (c *mockShiroClient) Seed(_ context.Context, version string, configs ...types.Config) error {
 	return fmt.Errorf("Seed(...) is not supported")
 }
 
 // ShiroPhylum implements the ShiroClient interface.
-func (c *mockShiroClient) ShiroPhylum(configs ...types.Config) (string, error) {
+func (c *mockShiroClient) ShiroPhylum(_ context.Context, configs ...types.Config) (string, error) {
 	return c.shiroPhylum, nil
 }
 
 // Init implements the ShiroClient interface.
-func (c *mockShiroClient) Init(phylum string, configs ...types.Config) error {
-	cro, err := c.flatten(configs...)
+func (c *mockShiroClient) Init(ctx context.Context, phylum string, configs ...types.Config) error {
+	cro, err := c.flatten(ctx, configs...)
 	if err != nil {
 		return err
 	}
@@ -103,7 +102,7 @@ func (c *mockShiroClient) Init(phylum string, configs ...types.Config) error {
 
 // Call implements the ShiroClient interface.
 func (c *mockShiroClient) Call(ctx context.Context, method string, configs ...types.Config) (types.ShiroResponse, error) {
-	cro, err := c.flatten(configs...)
+	cro, err := c.flatten(ctx, configs...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +120,8 @@ func (c *mockShiroClient) Call(ctx context.Context, method string, configs ...ty
 }
 
 // QueryInfo implements the ShiroClient interface.
-func (c *mockShiroClient) QueryInfo(configs ...types.Config) (uint64, error) {
-	cro, err := c.flatten(configs...)
+func (c *mockShiroClient) QueryInfo(ctx context.Context, configs ...types.Config) (uint64, error) {
+	cro, err := c.flatten(ctx, configs...)
 	if err != nil {
 		return 0, err
 	}
@@ -131,8 +130,8 @@ func (c *mockShiroClient) QueryInfo(configs ...types.Config) (uint64, error) {
 }
 
 // QueryBlock implements the ShiroClient interface.
-func (c *mockShiroClient) QueryBlock(blockNumber uint64, configs ...types.Config) (types.Block, error) {
-	cro, err := c.flatten(configs...)
+func (c *mockShiroClient) QueryBlock(ctx context.Context, blockNumber uint64, configs ...types.Config) (types.Block, error) {
+	cro, err := c.flatten(ctx, configs...)
 	if err != nil {
 		return nil, err
 	}

--- a/shiroclient/batch/batch_test.go
+++ b/shiroclient/batch/batch_test.go
@@ -59,7 +59,9 @@ func Test001(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	err = client.Init(shiroclient.EncodePhylumBytes(testPhylum))
+	ctx := context.Background()
+
+	err = client.Init(ctx, shiroclient.EncodePhylumBytes(testPhylum))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,8 +69,6 @@ func Test001(t *testing.T) {
 	driver := batch.NewDriver(client, batch.WithLog(log), batch.WithLogField("TESTFIELD", "TESTVALUE"))
 
 	lastReceivedMessage := "none"
-
-	ctx := context.Background()
 
 	ticker := driver.Register(ctx, "test_batch", time.Duration(1)*time.Hour, func(batchID string, requestID string, message json.RawMessage) (json.RawMessage, error) {
 		messageStr := string(message)

--- a/shiroclient/configs.go
+++ b/shiroclient/configs.go
@@ -17,13 +17,6 @@ func WithHTTPClient(client *http.Client) Config {
 	})
 }
 
-// WithContext allows specifying the context to use.
-func WithContext(ctx context.Context) Config {
-	return types.Opt(func(r *types.RequestOptions) {
-		r.Ctx = ctx
-	})
-}
-
 // WithLog allows specifying the logger to use.
 func WithLog(log *logrus.Logger) Config {
 	return types.Opt(func(r *types.RequestOptions) {

--- a/shiroclient/private/private_test.go
+++ b/shiroclient/private/private_test.go
@@ -21,14 +21,15 @@ func newMockClient() (shiroclient.MockShiroClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	version, err := client.ShiroPhylum()
+	ctx := context.Background()
+	version, err := client.ShiroPhylum(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if version != "test" {
 		return nil, fmt.Errorf("expected version 'test'")
 	}
-	err = client.Init(shiroclient.EncodePhylumBytes(testPhylum))
+	err = client.Init(ctx, shiroclient.EncodePhylumBytes(testPhylum))
 	if err != nil {
 		return nil, err
 	}

--- a/shiroclient/shiroclient_test.go
+++ b/shiroclient/shiroclient_test.go
@@ -45,7 +45,7 @@ func call(client shiroclient.ShiroClient, method string, params interface{}, tra
 
 func initClient(t *testing.T, client shiroclient.ShiroClient, phylum []byte) {
 	t.Helper()
-	err := client.Init(shiroclient.EncodePhylumBytes(phylum))
+	err := client.Init(context.Background(), shiroclient.EncodePhylumBytes(phylum))
 	require.NoError(t, err)
 }
 
@@ -57,7 +57,7 @@ func TestHealth(t *testing.T) {
 		require.NoError(t, err)
 	})
 	initClient(t, client, testPhylum)
-	version, err := client.ShiroPhylum()
+	version, err := client.ShiroPhylum(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "test", version)
 

--- a/shiroclient/update/update_test.go
+++ b/shiroclient/update/update_test.go
@@ -23,7 +23,7 @@ func client(t *testing.T) shiroclient.ShiroClient {
 	t.Helper()
 	client, err := shiroclient.NewMock(nil)
 	require.NoError(t, err)
-	err = client.Init(shiroclient.EncodePhylumBytes(testPhylum))
+	err = client.Init(context.Background(), shiroclient.EncodePhylumBytes(testPhylum))
 	require.NoError(t, err)
 	return client
 }
@@ -98,7 +98,9 @@ func TestInstall(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("init-2", func(t *testing.T) {
-		err := client.Init(shiroclient.EncodePhylumBytes(testPhylum), plugin.WithNewPhylumVersion("new"), shiroclient.WithContext(ctx))
+		err := client.Init(ctx,
+			shiroclient.EncodePhylumBytes(testPhylum),
+			plugin.WithNewPhylumVersion("new"))
 		require.NoError(t, err)
 
 		phyla, err := update.GetPhyla(ctx, client)

--- a/x/plugin/args.go
+++ b/x/plugin/args.go
@@ -16,11 +16,7 @@ type pluginArgs struct {
 }
 
 func PluginArgs(configs []types.Config) pluginArgs {
-	return pluginArgs{ro: types.ApplyConfigs(context.TODO(), nil, configs...)}
-}
-
-func PluginCtx(p pluginArgs) context.Context {
-	return p.ro.Ctx
+	return pluginArgs{ro: types.ApplyConfigs(nil, configs...)}
 }
 
 func PluginID(p pluginArgs) string {


### PR DESCRIPTION
This updates the APIs to take mandatory context parameters and pass them through wherever possible.  The context is mostly thrown away for mock mode at present.