### PR TITLE
feat(mock): add WithPreheatTimeout to configure phylum init timeout

### DIFF
--- a/internal/mock/shiroclient.go
+++ b/internal/mock/shiroclient.go
@@ -265,7 +265,9 @@ func NewMock(clientConfigs []types.Config, opts ...mock.Option) (MockShiroClient
 		}
 	}
 	var tag string
-	tag, err = conn.GetSubstrate().NewMockFrom(mockint.PhylumName, mockint.PhylumVersion, snapshot)
+	tag, err = conn.GetSubstrate().NewMockFrom(mockint.PhylumName, mockint.PhylumVersion, snapshot, plugin.MockOptions{
+		PreheatTimeout: config.PreheatTimeout,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mock client: %w", err)
 	}

--- a/internal/mockint/mockint.go
+++ b/internal/mockint/mockint.go
@@ -2,6 +2,7 @@ package mockint
 
 import (
 	"io"
+	"time"
 )
 
 const (
@@ -23,4 +24,7 @@ type Config struct {
 	LogWriter      io.Writer
 	LogLevel       LogLevel
 	SnapshotReader io.Reader
+	// PreheatTimeout overrides the substrate phylum preheat/init timeout. A
+	// non-positive value leaves the substrate default in effect.
+	PreheatTimeout time.Duration
 }

--- a/shiroclient/mock/option.go
+++ b/shiroclient/mock/option.go
@@ -4,6 +4,7 @@ package mock
 
 import (
 	"io"
+	"time"
 
 	"github.com/luthersystems/shiroclient-sdk-go/internal/mockint"
 )
@@ -53,5 +54,19 @@ func WithLogLevel(level mockint.LogLevel) Option {
 func WithSnapshotReader(r io.Reader) Option {
 	return func(config *mockint.Config) {
 		config.SnapshotReader = r
+	}
+}
+
+// WithPreheatTimeout overrides the substrate phylum preheat/init timeout for
+// the mock. A non-positive duration leaves the substrate default (6s) in
+// effect. Raising it helps avoid spurious "phylum init timeout" errors when
+// many mock clients initialize in parallel under heavy CPU load, e.g. large Go
+// test suites running with high parallelism.
+//
+// This requires a substratehcp plugin built from a substrate version that
+// honors the option; older plugins silently ignore it.
+func WithPreheatTimeout(d time.Duration) Option {
+	return func(config *mockint.Config) {
+		config.PreheatTimeout = d
 	}
 }

--- a/x/plugin/plugin.go
+++ b/x/plugin/plugin.go
@@ -11,11 +11,22 @@ import (
 	"net/rpc"
 	"os"
 	"os/exec"
+	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"github.com/luthersystems/shiroclient-sdk-go/internal/types"
 )
+
+// MockOptions carries construction-time options for a mock substrate created
+// via NewMockFrom. Fields are plain data so the struct can travel across the
+// plugin RPC boundary. A zero value selects substrate defaults for every
+// field.
+type MockOptions struct {
+	// PreheatTimeout overrides the substrate phylum preheat/init timeout. A
+	// non-positive value uses the substrate default.
+	PreheatTimeout time.Duration
+}
 
 // ConcreteRequestOptions is a variant of RequestOptions that is
 // "flattened" to pure data.
@@ -83,7 +94,7 @@ type Block struct {
 type Substrate interface {
 	HealthCheck(int) (int, error)
 
-	NewMockFrom(string, string, []byte) (string, error)
+	NewMockFrom(string, string, []byte, MockOptions) (string, error)
 	SetCreatorWithAttributesMock(string, string, map[string]string) error
 	SnapshotMock(string) ([]byte, error)
 	CloseMock(string) error
@@ -109,6 +120,9 @@ type ArgsNewMockFrom struct {
 	Name     string
 	Version  string
 	Snapshot []byte
+	// Options is decoded by gob; older plugin servers that predate this
+	// field simply ignore it, leaving substrate defaults in effect.
+	Options MockOptions
 }
 
 // RespNewMockFrom encodes the response from NewMockFrom
@@ -214,9 +228,9 @@ func (g *PluginRPC) HealthCheck(nat int) (int, error) {
 }
 
 // NewMockFrom forwards the call
-func (g *PluginRPC) NewMockFrom(name string, version string, snapshot []byte) (string, error) {
+func (g *PluginRPC) NewMockFrom(name string, version string, snapshot []byte, opts MockOptions) (string, error) {
 	var resp RespNewMockFrom
-	err := g.client.Call("Plugin.NewMockFrom", &ArgsNewMockFrom{Name: name, Version: version, Snapshot: snapshot}, &resp)
+	err := g.client.Call("Plugin.NewMockFrom", &ArgsNewMockFrom{Name: name, Version: version, Snapshot: snapshot, Options: opts}, &resp)
 	if err != nil {
 		return "", err
 	}
@@ -360,7 +374,7 @@ func (s *PluginRPCServer) HealthCheck(args *ArgsHealthCheck, resp *RespHealthChe
 
 // NewMockFrom forwards the call
 func (s *PluginRPCServer) NewMockFrom(args *ArgsNewMockFrom, resp *RespNewMockFrom) error {
-	tag, err := s.Impl.NewMockFrom(args.Name, args.Version, args.Snapshot)
+	tag, err := s.Impl.NewMockFrom(args.Name, args.Version, args.Snapshot, args.Options)
 	if err != nil {
 		resp.Err = s.newError(err)
 		return nil


### PR DESCRIPTION
## Why

substrate enforces a hardcoded **6s phylum preheat/init timeout** (`preheatTimeout`). Under heavy CPU load — e.g. large Go test suites running many in-memory mock substrates in parallel — a cold phylum can take longer than 6s to initialize, producing spurious `phylum init timeout after 6s` errors and flaky tests (reported in acre).

There was no way to tune it: construction-time `shiroclient.Config` values don't cross the mock plugin boundary (only name/version/snapshot do), so a server-construction knob has to ride the `NewMockFrom` RPC.

## What

Adds a first-class, opt-in mock option that threads a preheat timeout across the plugin boundary:

- `mock.WithPreheatTimeout(d time.Duration)` → `mockint.Config.PreheatTimeout`
- new `plugin.MockOptions{PreheatTimeout}` carried on `ArgsNewMockFrom` / the `NewMockFrom` RPC
- `internal/mock.NewMock` passes it through to the plugin server

A non-positive duration leaves the substrate default (6s) in effect. The new gob field is backward/forward compatible — older plugins simply ignore it.

## Consumers (follow-up, after this releases)

- **substrate**: applies the value via a new `shiro.WithPreheatTimeout` ServerOpt in its mock plugin handler.
- **acre**: mock test clients pass `mock.WithPreheatTimeout(30s)`.

Both pin to the released tag once this is merged + tagged.

## Verification

- Full SDK test suite passes against a substrate `substratehcp-local` built with the matching server-side change.
- substrate e2e (`TestMockPreheatTimeout`): a slow-loading phylum against a 50ms configured timeout fails with `phylum init timeout after 50ms` — confirming the value crosses SDK → gob/plugin RPC → substrate.